### PR TITLE
Add .pre-commit-hooks.yaml for pre-commit framework support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,21 @@
+# For use
+- id: xygeni
+  name: xygeni (script)
+  description: Runs Xygeni scanner as a script
+  stages: [commit]
+  entry: xygeni
+  args: ['-q', 'scan', '--format=text', '--run=secrets,suspectdeps,misconf,iac,codetamper,compliance', '--fail-on=severity:critical']
+  language: script
+  pass_filenames: false
+  always_run: true
+
+- id: xygeni-docker
+  name: xygeni (docker)
+  description: Runs Xygeni scanner docker image
+  stages: [commit]
+  language: docker
+  entry: -e XYGENI_TOKEN xygeni/xygeni_scanner:latest
+  args: ['-q', 'scan', '--format=text', '--run=secrets,suspectdeps,misconf,iac,codetamper,compliance', '--fail-on=severity:critical']
+  pass_filenames: false
+  always_run: true
+


### PR DESCRIPTION
Add new `.pre-commit-hooks.yaml` so Xygeni scan can be run a pre-commit script under the [pre-commit framework](https://pre-commit.com/).

See [creating new hooks](https://pre-commit.com/#creating-new-hooks) for details of the YAML file.