### PR TITLE
v5.38.1

### DIFF
--- a/.github/workflows/testing-demo.yml
+++ b/.github/workflows/testing-demo.yml
@@ -14,13 +14,12 @@ jobs:
     runs-on: ubuntu-latest
   
     steps:
-    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
-
     - name: Xygeni-Scanner-Demo
-      uses: xygeni/xygeni-action@4e94e5ea737f5ebfedac8b1a5b75d8c60c21932d
+      uses: xygeni/xygeni-action@v5
       id: Xygeni-Scanner
       with:
         command: scan --never-fail -o ./XygeniAction.json -f json
@@ -28,43 +27,43 @@ jobs:
         gh_token: ${{ secrets.GH_PAT_FOR_DOGFOODING }}
         xygeni_url: https://apidemo.xygeni.io/deps-doctor-service
     - name: Upload scan report result (deps)
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      uses: actions/upload-artifact@v6
       with:
           name: deps.XygeniAction.json
           path: ./deps.XygeniAction.json
           retention-days: 1
     - name: Upload scan report result (suspectdeps)
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      uses: actions/upload-artifact@v6
       with:
           name: suspectdeps.XygeniAction.json
           path: ./suspectdeps.XygeniAction.json
           retention-days: 1
     - name: Upload scan report result (secrets)
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      uses: actions/upload-artifact@v6
       with:
           name: secrets.XygeniAction.json
           path: ./secrets.XygeniAction.json
           retention-days: 1
     - name: Upload scan report result (misconf)
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      uses: actions/upload-artifact@v6
       with:
           name: misconf.XygeniAction.json
           path: ./misconf.XygeniAction.json
           retention-days: 1
     - name: Upload scan report result (iac)
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      uses: actions/upload-artifact@v6
       with:
           name: iac.XygeniAction.json
           path: ./iac.XygeniAction.json
           retention-days: 1
     - name: Upload scan report result (malware)
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      uses: actions/upload-artifact@v6
       with:
           name: malware.XygeniAction.json
           path: ./malware.XygeniAction.json
           retention-days: 1
     - name: Upload scan report result (sast)
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      uses: actions/upload-artifact@v6
       with:
           name: sast.XygeniAction.json
           path: ./sast.XygeniAction.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Latest Release](https://img.shields.io/github/v/release/xygeni/xygeni-action)](https://github.com/xygeni/xygeni-action/releases/latest)
+
 # xygeni-action
 
 GitHub Action for Xygeni Scanner.
@@ -91,13 +93,13 @@ jobs:
       # Checkout the repository sources (GITHUB_WORKSPACE)
       - name: Checkout
         # You may instead pin to an action SHA
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           # The default depth of 1 commit is not enough for some scans
           fetch-depth: 0
 
       - name: Xygeni-Scanner
-        uses: xygeni/xygeni-action@v5.38.0
+        uses: xygeni/xygeni-action@v5
         id: Xygeni-Scanner
         with:
           token: ${{ secrets.XYGENI_TOKEN }}
@@ -131,17 +133,18 @@ The available parameters for the action are:
 > **Tip:** Use `--run=secrets,iac` if you want to scan only for secrets and IaC flaws, for example.
 
 > **Tip:** If you want to analyze a subdirectory, you can configure the command with `-d` parameter.
-> For example, use `-d /app` if the directory to scan is the `app` directory in your repository.
+> For example, use `-d app` if the directory to scan is the `app` directory in your repository.
 
 Example for scanning only hard-coded secrets and IaC flaws in the `app` subdirectory, and failing the build only when critical issues are found:
 
 ```yaml
   - name: Xygeni-Scanner
-    uses: xygeni/xygeni-action@v5.38.0
+    # Recommended: use commit SHA instead
+    uses: xygeni/xygeni-action@v5
     id: Xygeni-Scanner
     with:
       token: ${{ secrets.XYGENI_TOKEN }}
-      command: scan -n ${{ github.repository }} -d /app --run=secrets,iac --fail-on=critical
+      command: scan -n ${{ github.repository }} -d app --run=secrets,iac --fail-on=critical
 ```
 
 See [Xygeni scan command](https://docs.xygeni.io/xygeni-scanner-cli/xygeni-cli-overview/xygeni-cli-operation-modes/single-scan) for full information on the `command` options available.

--- a/README.md
+++ b/README.md
@@ -90,10 +90,16 @@ jobs:
     steps:
       # Checkout the repository sources (GITHUB_WORKSPACE)
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        # You may instead pin an action SHA, like this: 
+        # uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        uses: actions/checkout@v3.5.3
+        with:
+          # The default depth of 1 commit is not enough for some scans 
+          fetch-depth: 0
         
       - name: Xygeni-Scanner
-        uses: xygeni/xygeni-action@v2.0
+        # Pinned: xygeni/xygeni@4e94e5ea737f5ebfedac8b1a5b75d8c60c21932d
+        uses: xygeni/xygeni-action@v2.1
         id: Xygeni-Scanner
         with:
           token: ${{ secrets.XYGENI_TOKEN }}
@@ -125,7 +131,7 @@ The available parameters for the action are:
 
 > **Tip:** Use `--run=secrets,iac` if you want to scan only for secrets and IaC flaws, for example.
 
-> **Tip** If you want analyze a subdirectory, you can configure the command with `-d` parameter starting with `/app/{YOUR PATH IN THE APPLICATION}`.
+> **Tip** If you want to analyze a subdirectory, you can configure the command with `-d` parameter starting with `/app/{YOUR PATH IN THE APPLICATION}`.
 
 Example for scanning only hard-coded secrets and IaC flaws detectors, and failing the build only when critical issues are found:
 
@@ -135,5 +141,5 @@ Example for scanning only hard-coded secrets and IaC flaws detectors, and failin
     id: Xygeni-Scanner
     with:
       token: ${{ secrets.XYGENI_TOKEN }}
-      command: scan -n ${{ github.repository }} -d /app --run=secrets,iac --fail-on=severity:critical
+      command: scan -n ${{ github.repository }} -d /app --run=secrets,iac --fail-on=critical
 ```

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   command:
     description: 'Command to execute by the scanner'
     required: false
-    default: 'scan --never-fail'
+    default: scan --never-fail -d $GITHUB_WORKSPACE
   gh_token:
     description: 'GitHub token to retrieve repository information for misconfigurations and compliance.'
     required: false
@@ -49,7 +49,9 @@ runs:
 
     - name: 'Run Xygeni Scanner'
       shell: bash
-      run: $HOME/.xygeni/xygeni ${{ inputs.command }} -d ${{ github.workspace }}
+      run: |
+        echo "Running xygeni ${{ inputs.command }}" 
+        $HOME/.xygeni/xygeni ${{ inputs.command }}
       env:
         XYGENI_TOKEN: ${{ inputs.token }}
         XYGENI_URL: ${{ inputs.xygeni_url }}

--- a/workflow-templates/code-scanning/properties/xygeni.properties.json
+++ b/workflow-templates/code-scanning/properties/xygeni.properties.json
@@ -1,0 +1,12 @@
+{
+  "name": "Xygeni",
+  "creator": "Xygeni Security",
+  "description": "Protect the integrity and security of your software assets, pipelines and infrastructure of the entire software supply chain.",
+  "iconName": "xygeni",
+  "categories": [
+    "Code Scanning",
+    "Build Security",
+    "CI/CD Security",
+    "Software Supply Chain"
+  ]
+}

--- a/workflow-templates/code-scanning/xygeni.yml
+++ b/workflow-templates/code-scanning/xygeni.yml
@@ -1,0 +1,87 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by separate terms of service,
+# privacy policy, and support documentation.
+
+# A sample workflow which sets up Xygeni to analyze the build & deploy system
+# (secret leaks, IaC flaws, code tampering, misconfigurations, risky components,
+# plus standards compliance and inventory). The results are then uploaded to Xygeni
+# and (optionally) to GitHub, either in Code Scanning or Commit Status.
+#
+# To use the Xygeni Action that runs the scan you will need an API token.
+# See https://docs.xygeni.io/xydocs/administration/administration.html#_generate_token_for_scanner
+# and https://github.com/marketplace/actions/xygeni-scanner#setting-api-token-as-encrypted-secret-in-github.
+#
+# For further details, read the documentation at:
+# - https://docs.xygeni.io/xydocs/integrations/ci/github_actions.html
+# - https://docs.xygeni.io/xydocs/howto/monitoring_pipelines.html
+
+name: Xygeni Security
+
+on:
+  push:
+    branches: [$default-branch, $protected-branches]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [$default-branch]
+  schedule:
+    - cron: $cron-weekly
+
+permissions:
+  contents: read
+
+jobs:
+  xygeni:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # to upload results to Code Scanning
+      actions: read # needed to get the Action run status
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        # You may pin an action SHA, like this:
+        # uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full git history for better code tampering detection.
+          fetch-depth: 0
+
+      - name: Xygeni scan
+        # You may pin an action SHA, like this:
+        # uses: xygeni/xygeni@4e94e5ea737f5ebfedac8b1a5b75d8c60c21932d
+        uses: xygeni/xygeni@2.1
+        with:
+          # Store you Xygeni api token as a repo/organization/environment secret
+          token: ${{ secrets.XYGENI_TOKEN }}
+          # For analyzing misconfigurations in your GitHub repos/organization you may use a token with more permissions
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Default: run all scans, upload to Xygeni, send findings to Code Scanning alerts
+          command: >
+            scan 
+              --name ${{ github.repository }} --dir /app 
+              --send-to=github/alerts --try-all-scans --never-fail
+
+          # Alternate command examples:
+          #   --run=inventory,codetamper,secrets,suspectdeps,iac,misconf,compliance
+          #   --send-to=github/alerts|github/status
+          #
+          ## Run partial scans and send findings to Commit status/comments
+          #command: >
+          #  scan
+          #    --run=inventory,codetamper,secrets,suspectdeps,iac
+          #    --name ${{ github.repository }} --dir /app
+          #    --send-to=github/status --try-all-scans --never-fail
+          #
+          ## Run partial scans, do not upload, send findings to Commit status/comments, fail the build if critical issue
+          #command: >
+          #  scan
+          #    --run=codetamper,secrets,misconf,suspectdeps,iac
+          #    --name ${{ github.repository }} --dir /app
+          #    --send-to=github/status --no-upload --try-all-scans --fail-on=critical
+          #
+          ## Run a single scan (codetamper) to check if a critical file was modified without review
+          #command: >
+          #  codetamper -n ${{ github.repository }} -d /app --upload --send-to=github/status --fail-on=critical
+

--- a/workflow-templates/code-scanning/xygeni.yml
+++ b/workflow-templates/code-scanning/xygeni.yml
@@ -39,23 +39,23 @@ jobs:
     steps:
       - name: Checkout
         # You may pin to an action SHA
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           # Full git history for better code tampering detection.
           fetch-depth: 0
 
       - name: Xygeni scan
-        uses: xygeni/xygeni-action@v5.38.0
+        uses: xygeni/xygeni-action@v5
         with:
           # Store you Xygeni api token as a repo/organization/environment secret
           token: ${{ secrets.XYGENI_TOKEN }}
-          # For analyzing misconfigurations in your GitHub repos/organization you may use a token with more permissions
+          # For analyzing misconfigurations in your GitHub repos/organization, you may use a token with more permissions
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Default: run all scans, upload to Xygeni, send findings to Code Scanning alerts
           command: >
             scan 
-              --name ${{ github.repository }} --dir /app 
+              --name "${{ github.repository }}" --dir . 
               --send-to=github/alerts --try-all-scans --never-fail
 
           # Alternate command examples:
@@ -66,17 +66,18 @@ jobs:
           #command: >
           #  scan
           #    --run=inventory,codetamper,secrets,suspectdeps,iac
-          #    --name ${{ github.repository }} --dir /app
+          #    --name "${{ github.repository }}"
           #    --send-to=github/status --try-all-scans --never-fail
           #
-          ## Run partial scans, do not upload, send findings to Commit status/comments, fail the build if critical issue
+          ## Run partial scans on the 'app' subdir, do not upload, send findings to Commit status/comments,
+          ## fail the build if critical issue
           #command: >
           #  scan
-          #    --run=codetamper,secrets,misconf,suspectdeps,iac
-          #    --name ${{ github.repository }} --dir /app
+          #    --run=secrets,misconf,suspectdeps,iac
+          #    --name "${{ github.repository }}" --dir app
           #    --send-to=github/status --no-upload --try-all-scans --fail-on=critical
           #
           ## Run a single scan (codetamper) to check if a critical file was modified without review
           #command: >
-          #  codetamper -n ${{ github.repository }} -d /app --upload --send-to=github/status --fail-on=critical
+          #  codetamper -n "${{ github.repository }}" --upload --send-to=github/status --fail-on=critical
 


### PR DESCRIPTION
- Use version shortcut (v5) in docs for simplicity.
- Added v5 shortcut tag.
- Removed the incorrect path prefix  (e.g. /app), as the current workdir is the repository home itself.