### PR TITLE
Update README references to v6 and add SHA pinning tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,19 @@ jobs:
           fetch-depth: 0
 
       - name: Xygeni-Scanner
-        uses: xygeni/xygeni-action@v5
+        uses: xygeni/xygeni-action@v6
         id: Xygeni-Scanner
         with:
           token: ${{ secrets.XYGENI_TOKEN }}
 ```
 
 Where `XYGENI_TOKEN` is the name of the encrypted secret where the API token was saved.
+
+> TIP: For enhanced security, you can pin the action to a specific commit SHA instead of a version tag.
+> Find the commit SHA for a release at https://github.com/xygeni/xygeni-action/releases and use it as follows:
+> ```yaml
+> uses: xygeni/xygeni-action@<commit-sha>
+> ```
 
 > TIP: There is a [starter workflow](https://docs.github.com/en/actions/using-workflows/using-starter-workflows) for Xygeni, which provides assistance for creating a scan job with Xygeni.
 > Just go to `Actions` tab, click on `New Workflow` button, and write `xygeni` in the `Search workflows` field.
@@ -140,7 +146,7 @@ Example for scanning only hard-coded secrets and IaC flaws in the `app` subdirec
 ```yaml
   - name: Xygeni-Scanner
     # Recommended: use commit SHA instead
-    uses: xygeni/xygeni-action@v5
+    uses: xygeni/xygeni-action@v6
     id: Xygeni-Scanner
     with:
       token: ${{ secrets.XYGENI_TOKEN }}


### PR DESCRIPTION
## Summary

- Updated all action usage examples from `xygeni/xygeni-action@v5` to `xygeni/xygeni-action@v6`
- Added a tip about pinning the action to a specific commit SHA for enhanced security

## Release checklist

After this PR is merged, create the `v6.4.0` release for the GitHub Marketplace:

1. **Create the release:**
   ```bash
   gh release create v6.4.0 --target main \
     --title "v6.4.0" \
     --generate-notes
   ```

2. **Create/update the `v6` floating tag** (so `@v6` always points to the latest v6.x.x):
   ```bash
   git tag -f v6 v6.4.0
   git push -f origin v6
   ```

3. **Publish to GitHub Marketplace** from the [Releases page](https://github.com/xygeni/xygeni-action/releases) by checking "Publish this Action to the GitHub Marketplace" when editing the release.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] After merge, create `v6.4.0` release and `v6` floating tag
- [ ] Verify `xygeni/xygeni-action@v6` resolves correctly
- [ ] Confirm the action is listed on the GitHub Marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)