### PR TITLE
commit-pinned all actions in README and workflow template

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,13 @@ jobs:
     steps:
       # Checkout the repository sources (GITHUB_WORKSPACE)
       - name: Checkout
-        # You may instead pin to an action SHA
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # The default depth of 1 commit is not enough for some scans
           fetch-depth: 0
 
       - name: Xygeni-Scanner
-        uses: xygeni/xygeni-action@v6
+        uses: xygeni/xygeni-action@13c6ed2797df7d85749864e2cbcf09c893f43b23 # v6.4.0
         id: Xygeni-Scanner
         with:
           token: ${{ secrets.XYGENI_TOKEN }}
@@ -145,8 +144,7 @@ Example for scanning only hard-coded secrets and IaC flaws in the `app` subdirec
 
 ```yaml
   - name: Xygeni-Scanner
-    # Recommended: use commit SHA instead
-    uses: xygeni/xygeni-action@v6
+    uses: xygeni/xygeni-action@13c6ed2797df7d85749864e2cbcf09c893f43b23 # v6.4.0
     id: Xygeni-Scanner
     with:
       token: ${{ secrets.XYGENI_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ When using this action, we recommend:
 
 1. **Store API tokens as GitHub Encrypted Secrets** - Never hardcode tokens in workflows.
 2. **Use the latest version** - Keep the action updated to receive security fixes.
-3. **Pin to a specific version** - Use exact version tags (e.g., `@v5.38.0`) rather than floating tags.
+3. **Pin to a specific commit SHA** - Use commit SHAs (e.g., `@13c6ed2797df7d85749864e2cbcf09c893f43b23`) rather than version tags.
 4. **Limit token permissions** - Use tokens with the minimum required permissions.
 
 ## Security Features

--- a/workflow-templates/code-scanning/xygeni.yml
+++ b/workflow-templates/code-scanning/xygeni.yml
@@ -38,14 +38,13 @@ jobs:
 
     steps:
       - name: Checkout
-        # You may pin to an action SHA
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Full git history for better code tampering detection.
           fetch-depth: 0
 
       - name: Xygeni scan
-        uses: xygeni/xygeni-action@v5
+        uses: xygeni/xygeni-action@13c6ed2797df7d85749864e2cbcf09c893f43b23 # v6.4.0
         with:
           # Store you Xygeni api token as a repo/organization/environment secret
           token: ${{ secrets.XYGENI_TOKEN }}


### PR DESCRIPTION
All actions n documentation and sample workflow were pinned to the commit SHA for the latest release (6.4.0):

```yaml
      - name: Xygeni scan
        uses: xygeni/xygeni-action@13c6ed2797df7d85749864e2cbcf09c893f43b23 # v6.4.0
```